### PR TITLE
release: 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.1
+
+Update embedded SDK.
+* Android 4.0.1
+
 ## 4.0.0
 **Breaking changes**
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,6 +57,6 @@ android {
 }
 
 dependencies {
-    implementation 'io.elepay.android:elepay:4.0.0'
-    implementation 'io.elepay.android:elepay-checkout:4.0.0'
+    implementation 'io.elepay.android:elepay:4.0.1'
+    implementation 'io.elepay.android:elepay-checkout:4.0.1'
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.0.1"
   fake_async:
     dependency: transitive
     description:

--- a/ios/elepay_flutter/Package.swift
+++ b/ios/elepay_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "elepay-flutter", targets: ["elepay_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/elestyle/elepay-ios-sdk", from: "5.0.5")
+        .package(url: "https://github.com/elestyle/elepay-ios-sdk", exact: "5.0.5")
     ],
     targets: [
         .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: elepay_flutter
 description: elepay SDK wrapper for Flutter
-version: 4.0.0
+version: 4.0.1
 homepage: https://elepay.io
 
 environment:


### PR DESCRIPTION
## Release elepay_flutter 4.0.1

### Changes
- **Android**: bump embedded elepay Android SDK `4.0.0` → `4.0.1` (`io.elepay.android:elepay` + `elepay-checkout`).
- **iOS**: pin `ElepaySDK` to exact `5.0.5` (was a floating `from:` range); embedded SDK version unchanged — only hardens the constraint.
- Bump plugin version `4.0.0` → `4.0.1` (`pubspec.yaml`, `CHANGELOG.md`, `example/pubspec.lock`).

### Notes
- `example/ios` `Package.resolved` already resolves to `5.0.5`; unaffected by the `exact` change.